### PR TITLE
Mark as broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # <img src="plugin.video.srf_ch_replay/resources/icon.png" width="75" height="75" /> Unofficial SRF Replay (another official Kodi add-on)
 
+## Discontinued
+**This add-on was deprecated a while back and is now broken. A new version of this add-on "Unofficial SRG SSR Replay" has been launched that supports all the current features and some more. Information can be found under ["Unofficial SRG SSR Replay" Kodi Add-on Page](https://kodi.tv/addons/matrix/plugin.video.srgssr_ch_replay) or on ["Unofficial SRG SSR Replay" Github](https://github.com/ManBehindMooN/kodi_plugin_video_srgssr_ch_replay)**
+
 ## Migration
 This add-on has been migrated from [SRF Podcast Plugin](https://kodi.wiki/view/Add-on:SRF_Podcast_Plugin) [[source code](https://github.com/ambermoon/xbmc_plugin_video_srf_podcast_ch)] as its development seems to be on hold and unfortunately the add-on is not compatible with the newest Kodi version anymore. Thanks to all the previous developers who maintained the original add-on that I used and appreciated a lot.
 
 ## Add-on description
-**This add-on is deprecated and will just be kept alive in its current state as long as the current used API is working. No new features will be added. A new version of this add-on "Unofficial SRG SSR Replay" has been launched that supports all the current features and some more. Information can be found under ["Unofficial SRG SSR Replay" Kodi Add-on Page](https://kodi.tv/addons/matrix/plugin.video.srgssr_ch_replay) or on ["Unofficial SRG SSR Replay" Github](https://github.com/ManBehindMooN/kodi_plugin_video_srgssr_ch_replay)**
-
 The add-on has been renamed to "Unofficial SRF Replay". It only supports the SRF channel and the only feature is to list and play this TV show library. All other channels and features from the original add-on have been refactored out. You might ask yourself 'Why?'. Well, never put avocado on a burger! Simple is always best!
 
 Since the tag 2.0.0 the add-on is in the official [Kodi 19 (Matrix) repository](https://github.com/xbmc/repo-plugins/tree/matrix/plugin.video.srf_ch_replay) / [Kodi Add-on Page](https://kodi.tv/addons/matrix/plugin.video.srf_ch_replay).

--- a/plugin.video.srf_ch_replay/README.md
+++ b/plugin.video.srf_ch_replay/README.md
@@ -2,12 +2,13 @@
 
 # Unofficial SRF Replay
 
+## Discontinued
+**This add-on was deprecated a while back and is now broken. A new version of this add-on "Unofficial SRG SSR Replay" has been launched that supports all the current features and some more. Information can be found under ["Unofficial SRG SSR Replay" Kodi Add-on Page](https://kodi.tv/addons/matrix/plugin.video.srgssr_ch_replay) or on ["Unofficial SRG SSR Replay" Github](https://github.com/ManBehindMooN/kodi_plugin_video_srgssr_ch_replay)**
+
 ## Migration
 This add-on has been migrated from [SRF Podcast Plugin](https://kodi.wiki/view/Add-on:SRF_Podcast_Plugin) [[source code](https://github.com/ambermoon/xbmc_plugin_video_srf_podcast_ch)] as its development seems to be on hold and unfortunately the add-on is not compatible with the newest Kodi version anymore. Thanks to all the previous developers who maintained the original add-on that I used and appreciated a lot.
 
 ## Add-on description
-**This add-on is deprecated and will just be kept alive in its current state as long as the current used API is working. No new features will be added. A new version of this add-on "Unofficial SRG SSR Replay" has been launched that supports all the current features and some more. Information can be found under ["Unofficial SRG SSR Replay" Kodi Add-on Page](https://kodi.tv/addons/matrix/plugin.video.srgssr_ch_replay) or on ["Unofficial SRG SSR Replay" Github](https://github.com/ManBehindMooN/kodi_plugin_video_srgssr_ch_replay)**
-
 The add-on has been renamed to "Unofficial SRF Replay". It only supports the SRF channel and the only feature is to list and play this TV show library. All other channels and features from the original add-on have been refactored out. You might ask yourself 'Why?'. Well, never put avocado on a burger! Simple is always best!
 
 All other usage information can be found on the [README on github](https://github.com/ManBehindMooN/kodi_plugin_video_srf_ch_replay)

--- a/plugin.video.srf_ch_replay/addon.xml
+++ b/plugin.video.srf_ch_replay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.srf_ch_replay" name="Unofficial SRF Replay" version="2.0.3" provider-name="Man Behind MooN">
+<addon id="plugin.video.srf_ch_replay" name="Unofficial SRF Replay" version="2.0.4" provider-name="Man Behind MooN">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -13,19 +13,20 @@
 - Fanart added with final design
 - No new features will be added to this add-on (see disclaimer)
 - A new add-on "Unofficial SRG SSR Replay" has been launched that supports all current and more features
-[INFO] The TV show URL from the unofficial API changed
-[WARN] Last fix before the status changes from deprecated to broken</news>
+- The TV show URL from the unofficial API changed
+- Last fix before the status changes from deprecated to broken
+[WARN] This addon is broken. Please move to the "Unofficial SRG SSR Replay" add-on</news>
 	<assets>
 		<icon>resources/icon.png</icon>
 		<fanart>resources/fanart.png</fanart>
 	</assets>
-	<lifecyclestate type="deprecated" lang="en_GB">This add-on uses an unsupported &amp; unofficial API. This add-on migth not work anymore in the near future. Please move to the new "Unofficial SRG SSR Replay" add-on.</lifecyclestate>
-    <summary lang="en_GB">The unofficial SRF Replay add-on plays TV shows from the SRF channel.</summary>
-    <description lang="en_GB">The unofficial SRF Replay add-on streams recorded TV shows from the national Swiss German TV station SRF over the unofficial provided API. All the shows are mainly in German. All shows are legally owned by the SRG SSR and will only be streamed over this add-on. Some shows might be regional locked and can only be played by Swiss IP addresses. Please note that this add-on deprecated. Please move to the new "Unofficial SRG SSR Replay" add-on.</description>
+	<lifecyclestate type="broken" lang="en_GB">This add-on uses an unsupported &amp; unofficial API. This add-on is broken &amp; does not work anymore. Please move to the new "Unofficial SRG SSR Replay" add-on.</lifecyclestate>
+    <summary lang="en_GB">[DEPRECATED &amp; BROKEN] The unofficial SRF Replay add-on plays TV shows from the SRF channel.</summary>
+    <description lang="en_GB">[DEPRECATED &amp; BROKEN] The unofficial SRF Replay add-on streams recorded TV shows from the national Swiss German TV station SRF over the unofficial provided API. All the shows are mainly in German. All shows are legally owned by the SRG SSR and will only be streamed over this add-on. Some shows might be regional locked and can only be played by Swiss IP addresses. Please note that this add-on is deprecated. Please move to the new "Unofficial SRG SSR Replay" add-on.</description>
     <disclaimer lang="en_GB">This add-on is not endorsed by SRG SSR and no support can be claimed. This add-on uses an unsupported API. This add-on is deprecated and will just be kept alive in its current state as long as the current used API is working. No new features will be added. A new version of this add-on "Unofficial SRG SSR Replay" has been launched that supports all the current features and some more.</disclaimer>
-	<lifecyclestate type="deprecated" lang="de_DE">Dieses Add-on benututz eine nicht supportete &amp; inoffizielle API. Dieses Add-on wird in naher Zukunft nicht mehr funktionieren. Bitte das neue "Unofficial SRG SSR Replay" Add-on benutzen.</lifecyclestate>
-	<summary lang="de_DE">Das inoffizielle SRF Replay Add-on zeigt alle SRF Sendungen.</summary>
-    <description lang="de_DE">Das inoffizielle SRF Replay Add-on zeigt aufgezeichneten Sendungen vom nationalen Schweizer deutschsprachigen TV Sender SRF über das zur Verfügung gestellte inoffizielle API. Die Sendungen sind hauptsächlich in deutscher Sprache. Alle Sendungen gehören der SRG SSR und werden vom Add-on lediglich gestreamt. Einige Sendungen können auf Regionen beschränkt sein und nur mit Schweizer IP Adressen abgespielt werden. Dieses Add-on ist veraltet. Bitte das neue "Unofficial SRG SSR Replay" Add-on benutzen.</description>
+	<lifecyclestate type="broken" lang="de_DE">Dieses Add-on benututz eine nicht supportete &amp; inoffizielle API. Dieses Add-on ist defekt &amp; funktioniert nicht mehr. Bitte das neue "Unofficial SRG SSR Replay" Add-on benutzen.</lifecyclestate>
+	<summary lang="de_DE">[VERALTET &amp; DEFEKT] Das inoffizielle SRF Replay Add-on zeigt alle SRF Sendungen.</summary>
+    <description lang="de_DE">[VERALTET &amp; DEFEKT] Das inoffizielle SRF Replay Add-on zeigt aufgezeichneten Sendungen vom nationalen Schweizer deutschsprachigen TV Sender SRF über das zur Verfügung gestellte inoffizielle API. Die Sendungen sind hauptsächlich in deutscher Sprache. Alle Sendungen gehören der SRG SSR und werden vom Add-on lediglich gestreamt. Einige Sendungen können auf Regionen beschränkt sein und nur mit Schweizer IP Adressen abgespielt werden. Dieses Add-on ist veraltet. Bitte das neue "Unofficial SRG SSR Replay" Add-on benutzen.</description>
     <disclaimer lang="de_DE">Dieses Add-on ist nicht offiziell von der SRG SSR und es bestehen keinerlei Support-Ansprüche. Das Add-on benutzt eine nicht supportete Schnittstelle. Dieses Add-on ist am Lebensende angekommen und wird nur noch solange die jetzt benutzte Schnittstelle funktioniert am Leben erhalten. Keine neuen Funktionen werden hinzugefügt. Ein neues Add-on "Unofficial SRG SSR Replay" steht zur Verfügung mit allen jetzigen und mehr Funktionen.</disclaimer>
     <language>de</language>
     <platform>all</platform>


### PR DESCRIPTION
The time has come...  episodes cannot be listed anymore:
Traceback (most recent call last):
                                                     File "\AppData\Roaming\Kodi\addons\plugin.video.srf_ch_replay\addon.py", line 280, in <module>
                                                       list_all_episodes(url, showbackground, page)
                                                     File "\AppData\Roaming\Kodi\addons\plugin.video.srf_ch_replay\addon.py", line 138, in list_all_episodes
                                                       response = json.load(open_srf_url(url))
                                                     File "\AppData\Roaming\Kodi\addons\plugin.video.srf_ch_replay\addon.py", line 51, in open_srf_url
                                                       xbmcgui.Dialog().ok(tr(30006), str(e.__class__.__name__), str(e))
                                                   TypeError: function takes at most 2 arguments (3 given)
                                                   -->End of Python script error report<--